### PR TITLE
fix(ruby-core-lib): fix returning nil instead of empty request params

### DIFF
--- a/apimatic_faraday_client_adapter.gemspec
+++ b/apimatic_faraday_client_adapter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'apimatic_faraday_client_adapter'
-  s.version = '0.1.3'
+  s.version = '0.1.4'
   s.summary = 'An adapter for faraday client library consumed by the SDKs generated with APIMatic.'
   s.description = 'Faraday is a simple, yet elegant, HTTP library. This repository contains the client '\
                   'implementation that uses the requests library for python SDK provided by APIMatic.'

--- a/lib/apimatic-faraday-client-adapter/faraday_client.rb
+++ b/lib/apimatic-faraday-client-adapter/faraday_client.rb
@@ -58,9 +58,7 @@ module CoreLibrary
         request.headers = http_request.headers.map { |k, v| [k.to_s, v.to_s] }
         request.options.context ||= {}
         request.options.context.merge!(http_request.context)
-        unless http_request.http_method == HttpMethod::GET && http_request.parameters.empty?
-          request.body = http_request.parameters
-        end
+        request.body = http_request.parameters
       end
       convert_response(response, http_request)
     end


### PR DESCRIPTION
## What
Fix returning nil instead of empty request params.
## Why
This behavior causes Faraday urlEncode middleware to assign content-type to x-www-form-urlencoded.

closes #16

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
